### PR TITLE
fixing undefined index if no nameservers are given

### DIFF
--- a/src/Easyname/RestApi/Client.php
+++ b/src/Easyname/RestApi/Client.php
@@ -324,7 +324,7 @@ class Client
     {
         $tmpNameservers = array();
         for ($i = 0; $i < 6; $i++) {
-            if ($nameservers[$i]) {
+            if (isset($nameservers[$i])) {
                 $tmpNameservers['nameserver' . ($i+1)] = $nameservers[$i];
             }
         }
@@ -367,7 +367,7 @@ class Client
     {
         $tmpNameservers = array();
         for ($i = 0; $i < 6; $i++) {
-            if ($nameservers[$i]) {
+            if (isset($nameservers[$i])) {
                 $tmpNameservers['nameserver' . ($i+1)] = $nameservers[$i];
             }
         }


### PR DESCRIPTION
If no nameservers are given undefined index notices are thrown.
